### PR TITLE
Plugin Compatibility Fixes for Nodeos 1.8.x

### DIFF
--- a/src/watcher_plugin.cpp
+++ b/src/watcher_plugin.cpp
@@ -93,9 +93,9 @@ namespace eosio {
 
 
       bool filter(const action_trace& act) {
-         if( filter_on.find({act.receipt.receiver, act.act.name}) != filter_on.end())
+         if( filter_on.find({act.receiver, act.act.name}) != filter_on.end())
             return true;
-         else if( filter_on.find({act.receipt.receiver, 0}) != filter_on.end())
+         else if( filter_on.find({act.receiver, 0}) != filter_on.end())
             return true;
          return false;
       }
@@ -119,15 +119,17 @@ namespace eosio {
          //~ ilog("on_action_trace - tx id: ${u}", ("u",tx_id));
          if( filter(act)) {
             action_queue.insert(std::make_pair(tx_id, sequenced_action(act.act, act_sequence,
-                                                                       act.receipt.receiver)));
+                                                                       act.receiver)));
             //~ ilog("Added to action_queue: ${u}", ("u",act.act));
          }
          act_sequence++;
 
+         /*
          for( const auto& iline : act.inline_traces ) {
             //~ ilog("Processing inline_trace: ${u}", ("u",iline));
             act_sequence = on_action_trace(iline, tx_id, act_sequence);
          }
+         */
 
          return act_sequence;
       }


### PR DESCRIPTION
### Fixed:
* [(Related Issue)](https://github.com/eosauthority/eosio-watcher-plugin/issues/13)
* After much trial & error, this fixes compilation issues when building this plugin with the latest stable release of Nodeos.
  * receiver is now located directly inside action (`action.receipt.receiver` -> `action.receiver`)
  * commented out the iteration on inline traces, these should all be flat transaction traces now
  * renamed `accepted_block_conn` to `accepted_block_connection`, and `applied_tx_conn` to `applied_transaction_connection`
  * Updated function signature for the lambda in `chain.applied_transaction.connect`

### Tested on:
* Ubuntu `18.04` (fresh install)
* Nodeos `1.8.5` 